### PR TITLE
refactor: update decorate method signatures to use typed parameters

### DIFF
--- a/templates/8.3/Model/InputObjectModel.php
+++ b/templates/8.3/Model/InputObjectModel.php
@@ -29,7 +29,7 @@ use <?=$import_class?>;
 }; ?>
 final class <?=$short_class_name?> extends InputType
 {
-    protected function decorate($name, $value)
+    protected function decorate(string $name, mixed $value): mixed
     {
         if ($value === null) {
             return null;

--- a/tests/Generator/Model/Psr4/fixtures/InputObjectModelGeneratorTest/case-1.php.txt
+++ b/tests/Generator/Model/Psr4/fixtures/InputObjectModelGeneratorTest/case-1.php.txt
@@ -15,7 +15,7 @@ use Axtiva\FlexibleGraphql\Type\InputType;
  */
 final class TestInputInputType extends InputType
 {
-    protected function decorate($name, $value)
+    protected function decorate(string $name, mixed $value): mixed
     {
         if ($value === null) {
             return null;

--- a/tests/Generator/Model/Psr4/fixtures/InputObjectModelGeneratorTest/case-2.php.txt
+++ b/tests/Generator/Model/Psr4/fixtures/InputObjectModelGeneratorTest/case-2.php.txt
@@ -15,7 +15,7 @@ use Axtiva\FlexibleGraphql\Type\InputType;
  */
 final class TestInputInputType extends InputType
 {
-    protected function decorate($name, $value)
+    protected function decorate(string $name, mixed $value): mixed
     {
         if ($value === null) {
             return null;


### PR DESCRIPTION
This pull request updates the method signature of the `decorate` method in the `InputObjectModel` and its generated test fixtures to use explicit type declarations for its parameters and return type. This improves type safety and code clarity.

**Type safety and code clarity improvements:**

* Updated the `decorate` method in `InputObjectModel.php` to explicitly declare the parameter types (`string $name, mixed $value`) and the return type (`mixed`).
* Updated the generated test fixture `TestInputInputType` classes in `case-1.php.txt` and `case-2.php.txt` to match the new method signature for `decorate`. [[1]](diffhunk://#diff-33956896bcf0f3fc634351e932fed3a311ac538ab53cc88ea26ae7a0779edbb6L18-R18) [[2]](diffhunk://#diff-912c738be76567eb95a3535b8c582e7694c9db06c306f7eab7197718edd4cfe1L18-R18)