### PR TITLE
feat: implement AmpFutureAdapter for Amphp v3 Promise integration to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Can easy to integrate graphql to any project, all you need is controller. Fast s
 - Support all features from [webonyx/graphql-php](https://github.com/webonyx/graphql-php)
 - Executable directives
 - Apollo Federation/Federation2 support
-- Amphp v3 support for async executions
+- [Amphp v3](#amphp-v3-async-execution) support for async executions
 - Popular framework integration:
   + Symfony [axtiva/flexible-graphql-bundle](//github.com/axtiva/flexible-graphql-bundle)
 
@@ -75,6 +75,43 @@ $container = new PsrContainerExample([
 ```
 
 Run demo app `php -S localhost:8080 example/start_graphql_server.php` and try request CodedCurrency.code field in query 
+
+## Amphp v3 Async Execution
+
+`AmpFutureAdapter` bridges [Amphp v3](https://amphp.org/) `Future` objects with the
+`webonyx/graphql-php` promise system, enabling fully non-blocking GraphQL execution.
+
+### Setup
+
+```php
+use Axtiva\FlexibleGraphql\Executor\AmpFutureAdapter;
+use GraphQL\Server\ServerConfig;
+use GraphQL\Server\StandardServer;
+use Amp\Future;
+
+$config = ServerConfig::create()
+    // ... schema, root value, etc.
+    ->setPromiseAdapter(new AmpFutureAdapter());
+
+$server = new StandardServer($config);
+$promise = $server->executePsrRequest($psrRequest);
+
+$response = null;
+if ($promise->adoptedPromise instanceof Future) {
+    $response = $promise->adoptedPromise->await()->toArray();
+}
+
+return new JsonResponse($response);
+```
+
+### Notes
+
+- Every field resolver that returns an Amphp `Future` is automatically wrapped via `Amp\async()` by the generated `TypeRegistry` when you use the `TypeRegistryGeneratorBuilderAmphp` builder.
+- `amphp/amp` is a **suggested** dependency; add it explicitly when async execution is needed:
+
+```
+composer require amphp/amp:^3
+```
 
 ## Tests
 

--- a/src/Executor/AmpFutureAdapter.php
+++ b/src/Executor/AmpFutureAdapter.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Axtiva\FlexibleGraphql\Executor;
+
+use Amp\DeferredFuture;
+use Amp\Future;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Executor\Promise\Promise;
+use GraphQL\Executor\Promise\PromiseAdapter;
+
+use function Amp\async;
+use function Amp\Future\await;
+
+final class AmpFutureAdapter implements PromiseAdapter
+{
+    public function isThenable($value): bool
+    {
+        return $value instanceof Future;
+    }
+
+    /** @throws InvariantViolation */
+    public function convertThenable($thenable): Promise
+    {
+        if (! $thenable instanceof Future) {
+            throw new InvariantViolation('Expected instance of Amp\\Future.');
+        }
+
+        return new Promise($thenable, $this);
+    }
+
+    /** @throws InvariantViolation */
+    public function then(
+        Promise $promise,
+        ?callable $onFulfilled = null,
+        ?callable $onRejected = null
+    ): Promise {
+        $future = $promise->adoptedPromise;
+
+        if (! $future instanceof Future) {
+            throw new InvariantViolation('Expected adopted promise to be instance of Amp\\Future.');
+        }
+
+        /** @var Future<mixed> $future */
+        $next = async(static function () use ($future, $onFulfilled, $onRejected) {
+            try {
+                $value = $future->await();
+
+                if ($onFulfilled === null) {
+                    return $value;
+                }
+
+                return self::unwrapResult($onFulfilled($value));
+            } catch (\Throwable $reason) {
+                if ($onRejected === null) {
+                    throw $reason;
+                }
+
+                return self::unwrapResult($onRejected($reason));
+            }
+        });
+
+        return new Promise($next, $this);
+    }
+
+    /** @throws InvariantViolation */
+    public function create(callable $resolver): Promise
+    {
+        $deferred = new DeferredFuture();
+
+        try {
+            $resolver(
+                static function ($value) use ($deferred): void {
+                    self::resolveDeferred($deferred, $value);
+                },
+                static function (\Throwable $exception) use ($deferred): void {
+                    $deferred->error($exception);
+                }
+            );
+        } catch (\Throwable $exception) {
+            $deferred->error($exception);
+        }
+
+        return new Promise($deferred->getFuture(), $this);
+    }
+
+    /**
+     * @throws \Error
+     * @throws InvariantViolation
+     */
+    public function createFulfilled($value = null): Promise
+    {
+        if ($value instanceof Promise) {
+            return $value;
+        }
+
+        if ($value instanceof Future) {
+            return new Promise($value, $this);
+        }
+
+        return new Promise(Future::complete($value), $this);
+    }
+
+    /** @throws InvariantViolation */
+    public function createRejected(\Throwable $reason): Promise
+    {
+        return new Promise(Future::error($reason), $this);
+    }
+
+    /**
+     * @throws \Error
+     * @throws InvariantViolation
+     */
+    public function all(iterable $promisesOrValues): Promise
+    {
+        $items = is_array($promisesOrValues)
+            ? $promisesOrValues
+            : iterator_to_array($promisesOrValues);
+
+        /** @var array<array-key, Future<mixed>> $futures */
+        $futures = [];
+
+        foreach ($items as $key => $item) {
+            if ($item instanceof Promise) {
+                $item = $item->adoptedPromise;
+            }
+
+            if ($item instanceof Future) {
+                $futures[$key] = $item;
+            }
+        }
+
+        $combined = async(static function () use ($items, $futures): array {
+            if ($futures === []) {
+                return $items;
+            }
+
+            $resolved = await($futures);
+
+            return array_replace($items, $resolved);
+        });
+
+        return new Promise($combined, $this);
+    }
+
+    /**
+     * @param DeferredFuture<mixed> $deferred
+     */
+    private static function resolveDeferred(DeferredFuture $deferred, mixed $value): void
+    {
+        if ($value instanceof Promise) {
+            $value = $value->adoptedPromise;
+        }
+
+        if ($value instanceof Future) {
+            async(static function () use ($deferred, $value): void {
+                try {
+                    $deferred->complete($value->await());
+                } catch (\Throwable $exception) {
+                    $deferred->error($exception);
+                }
+            });
+
+            return;
+        }
+
+        $deferred->complete($value);
+    }
+
+    private static function unwrapResult(mixed $value): mixed
+    {
+        if ($value instanceof Promise) {
+            $value = $value->adoptedPromise;
+        }
+
+        if ($value instanceof Future) {
+            return $value->await();
+        }
+
+        return $value;
+    }
+}

--- a/tests/Execution/AmpFutureAdapterTest.php
+++ b/tests/Execution/AmpFutureAdapterTest.php
@@ -1,0 +1,451 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Axtiva\FlexibleGraphql\Tests\Execution;
+
+use Amp\DeferredFuture;
+use Amp\Future;
+use Axtiva\FlexibleGraphql\Executor\AmpFutureAdapter;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Executor\Promise\Promise;
+use PHPUnit\Framework\TestCase;
+use Revolt\EventLoop;
+
+/**
+ * Unit tests for AmpFutureAdapter — the Amphp v3 PromiseAdapter implementation.
+ */
+class AmpFutureAdapterTest extends TestCase
+{
+    private AmpFutureAdapter $adapter;
+
+    protected function setUp(): void
+    {
+        $this->adapter = new AmpFutureAdapter();
+    }
+
+    // ------------------------------------------------------------------ isThenable
+
+    public function testIsThenableReturnsTrueForFuture(): void
+    {
+        $future = Future::complete(42);
+        $this->assertTrue($this->adapter->isThenable($future));
+    }
+
+    public function testIsThenableReturnsFalseForNonFuture(): void
+    {
+        $this->assertFalse($this->adapter->isThenable(42));
+        $this->assertFalse($this->adapter->isThenable('string'));
+        $this->assertFalse($this->adapter->isThenable(null));
+        $this->assertFalse($this->adapter->isThenable(new \stdClass()));
+    }
+
+    // ------------------------------------------------------------------ convertThenable
+
+    public function testConvertThenableWrapsAFutureInPromise(): void
+    {
+        $future = Future::complete('hello');
+        $promise = $this->adapter->convertThenable($future);
+
+        $this->assertInstanceOf(Promise::class, $promise);
+        $this->assertSame($future, $promise->adoptedPromise);
+    }
+
+    public function testConvertThenableThrowsForNonFuture(): void
+    {
+        $this->expectException(InvariantViolation::class);
+        $this->adapter->convertThenable('not-a-future');
+    }
+
+    // ------------------------------------------------------------------ createFulfilled
+
+    public function testCreateFulfilledWithScalarValue(): void
+    {
+        $promise = $this->adapter->createFulfilled(99);
+
+        $this->assertInstanceOf(Promise::class, $promise);
+        $this->assertInstanceOf(Future::class, $promise->adoptedPromise);
+
+        $value = null;
+        EventLoop::queue(static function () use ($promise, &$value): void {
+            /** @var Future<mixed> $future */
+            $future = $promise->adoptedPromise;
+            $value = $future->await();
+        });
+        EventLoop::run();
+
+        $this->assertSame(99, $value);
+    }
+
+    public function testCreateFulfilledWithFuturePassthrough(): void
+    {
+        $future = Future::complete('amp-value');
+        $promise = $this->adapter->createFulfilled($future);
+
+        $this->assertInstanceOf(Promise::class, $promise);
+        $this->assertSame($future, $promise->adoptedPromise);
+    }
+
+    public function testCreateFulfilledWithPromisePassthrough(): void
+    {
+        $inner = $this->adapter->createFulfilled('inner');
+        $outer = $this->adapter->createFulfilled($inner);
+
+        $this->assertSame($inner, $outer);
+    }
+
+    // ------------------------------------------------------------------ createRejected
+
+    public function testCreateRejectedStoresErrorFuture(): void
+    {
+        $exception = new \RuntimeException('test error');
+        $promise = $this->adapter->createRejected($exception);
+
+        $this->assertInstanceOf(Promise::class, $promise);
+        $this->assertInstanceOf(Future::class, $promise->adoptedPromise);
+
+        $caught = null;
+        EventLoop::queue(static function () use ($promise, &$caught): void {
+            try {
+                /** @var Future<mixed> $future */
+                $future = $promise->adoptedPromise;
+                $future->await();
+            } catch (\Throwable $e) {
+                $caught = $e;
+            }
+        });
+        EventLoop::run();
+
+        $this->assertSame($exception, $caught);
+    }
+
+    // ------------------------------------------------------------------ then
+
+    public function testThenCallsOnFulfilledWithResolvedValue(): void
+    {
+        $future = Future::complete(7);
+        $promise = $this->adapter->convertThenable($future);
+
+        $result = null;
+        $chainedPromise = $this->adapter->then(
+            $promise,
+            static function ($value) use (&$result): int {
+                $result = $value;
+                return $value * 2;
+            }
+        );
+
+        $this->assertInstanceOf(Promise::class, $chainedPromise);
+
+        EventLoop::queue(static function () use ($chainedPromise): void {
+            /** @var Future<mixed> $future */
+            $future = $chainedPromise->adoptedPromise;
+            $future->await();
+        });
+        EventLoop::run();
+
+        $this->assertSame(7, $result);
+    }
+
+    public function testThenReturnsTransformedValueFromOnFulfilled(): void
+    {
+        $future = Future::complete(3);
+        $promise = $this->adapter->convertThenable($future);
+
+        $chainedPromise = $this->adapter->then(
+            $promise,
+            static fn($v) => $v + 10
+        );
+
+        $resolved = null;
+        EventLoop::queue(static function () use ($chainedPromise, &$resolved): void {
+            /** @var Future<mixed> $future */
+            $future = $chainedPromise->adoptedPromise;
+            $resolved = $future->await();
+        });
+        EventLoop::run();
+
+        $this->assertSame(13, $resolved);
+    }
+
+    public function testThenPassesThroughWhenNoOnFulfilled(): void
+    {
+        $future = Future::complete('raw');
+        $promise = $this->adapter->convertThenable($future);
+
+        $chainedPromise = $this->adapter->then($promise);
+
+        $resolved = null;
+        EventLoop::queue(static function () use ($chainedPromise, &$resolved): void {
+            /** @var Future<mixed> $future */
+            $future = $chainedPromise->adoptedPromise;
+            $resolved = $future->await();
+        });
+        EventLoop::run();
+
+        $this->assertSame('raw', $resolved);
+    }
+
+    public function testThenCallsOnRejectedOnException(): void
+    {
+        $exception = new \RuntimeException('bang');
+        $future = Future::error($exception);
+        $promise = $this->adapter->convertThenable($future);
+
+        $caught = null;
+        $chainedPromise = $this->adapter->then(
+            $promise,
+            null,
+            static function (\Throwable $reason) use (&$caught): string {
+                $caught = $reason;
+                return 'recovered';
+            }
+        );
+
+        $resolved = null;
+        EventLoop::queue(static function () use ($chainedPromise, &$resolved): void {
+            /** @var Future<mixed> $future */
+            $future = $chainedPromise->adoptedPromise;
+            $resolved = $future->await();
+        });
+        EventLoop::run();
+
+        $this->assertSame($exception, $caught);
+        $this->assertSame('recovered', $resolved);
+    }
+
+    public function testThenRethrowsWhenNoOnRejected(): void
+    {
+        $exception = new \RuntimeException('unhandled');
+        $future = Future::error($exception);
+        $promise = $this->adapter->convertThenable($future);
+
+        $chainedPromise = $this->adapter->then($promise);
+
+        $caught = null;
+        EventLoop::queue(static function () use ($chainedPromise, &$caught): void {
+            try {
+                /** @var Future<mixed> $future */
+                $future = $chainedPromise->adoptedPromise;
+                $future->await();
+            } catch (\Throwable $e) {
+                $caught = $e;
+            }
+        });
+        EventLoop::run();
+
+        $this->assertSame($exception, $caught);
+    }
+
+    public function testThenThrowsWhenAdoptedPromiseIsNotFuture(): void
+    {
+        $promise = new Promise('not-a-future', $this->adapter);
+
+        $this->expectException(InvariantViolation::class);
+        $this->adapter->then($promise);
+    }
+
+    // ------------------------------------------------------------------ create
+
+    public function testCreateResolvesWithValue(): void
+    {
+        $promise = $this->adapter->create(static function ($resolve, $reject): void {
+            $resolve(42);
+        });
+
+        $this->assertInstanceOf(Promise::class, $promise);
+
+        $resolved = null;
+        EventLoop::queue(static function () use ($promise, &$resolved): void {
+            /** @var Future<mixed> $future */
+            $future = $promise->adoptedPromise;
+            $resolved = $future->await();
+        });
+        EventLoop::run();
+
+        $this->assertSame(42, $resolved);
+    }
+
+    public function testCreateRejectsWithException(): void
+    {
+        $exception = new \RuntimeException('create-reject');
+        $promise = $this->adapter->create(static function ($resolve, $reject) use ($exception): void {
+            $reject($exception);
+        });
+
+        $caught = null;
+        EventLoop::queue(static function () use ($promise, &$caught): void {
+            try {
+                /** @var Future<mixed> $future */
+                $future = $promise->adoptedPromise;
+                $future->await();
+            } catch (\Throwable $e) {
+                $caught = $e;
+            }
+        });
+        EventLoop::run();
+
+        $this->assertSame($exception, $caught);
+    }
+
+    public function testCreateCatchesExceptionFromResolver(): void
+    {
+        $exception = new \RuntimeException('thrown-in-resolver');
+        $promise = $this->adapter->create(static function ($resolve, $reject) use ($exception): void {
+            throw $exception;
+        });
+
+        $caught = null;
+        EventLoop::queue(static function () use ($promise, &$caught): void {
+            try {
+                /** @var Future<mixed> $future */
+                $future = $promise->adoptedPromise;
+                $future->await();
+            } catch (\Throwable $e) {
+                $caught = $e;
+            }
+        });
+        EventLoop::run();
+
+        $this->assertSame($exception, $caught);
+    }
+
+    public function testCreateResolvesWithFutureValue(): void
+    {
+        $inner = Future::complete('nested');
+        $promise = $this->adapter->create(static function ($resolve) use ($inner): void {
+            $resolve($inner);
+        });
+
+        $resolved = null;
+        EventLoop::queue(static function () use ($promise, &$resolved): void {
+            /** @var Future<mixed> $future */
+            $future = $promise->adoptedPromise;
+            $resolved = $future->await();
+        });
+        EventLoop::run();
+
+        $this->assertSame('nested', $resolved);
+    }
+
+    // ------------------------------------------------------------------ all
+
+    public function testAllResolvesArrayOfFutures(): void
+    {
+        $p1 = $this->adapter->createFulfilled('a');
+        $p2 = $this->adapter->createFulfilled('b');
+        $p3 = $this->adapter->createFulfilled('c');
+
+        $allPromise = $this->adapter->all([$p1, $p2, $p3]);
+        $this->assertInstanceOf(Promise::class, $allPromise);
+
+        $resolved = null;
+        EventLoop::queue(static function () use ($allPromise, &$resolved): void {
+            /** @var Future<mixed> $future */
+            $future = $allPromise->adoptedPromise;
+            $resolved = $future->await();
+        });
+        EventLoop::run();
+
+        $this->assertSame(['a', 'b', 'c'], $resolved);
+    }
+
+    public function testAllResolvesEmptyArray(): void
+    {
+        $allPromise = $this->adapter->all([]);
+
+        $resolved = null;
+        EventLoop::queue(static function () use ($allPromise, &$resolved): void {
+            /** @var Future<mixed> $future */
+            $future = $allPromise->adoptedPromise;
+            $resolved = $future->await();
+        });
+        EventLoop::run();
+
+        $this->assertSame([], $resolved);
+    }
+
+    public function testAllPreservesKeys(): void
+    {
+        $p1 = $this->adapter->createFulfilled(1);
+        $p2 = $this->adapter->createFulfilled(2);
+
+        $allPromise = $this->adapter->all(['x' => $p1, 'y' => $p2]);
+
+        $resolved = null;
+        EventLoop::queue(static function () use ($allPromise, &$resolved): void {
+            /** @var Future<mixed> $future */
+            $future = $allPromise->adoptedPromise;
+            $resolved = $future->await();
+        });
+        EventLoop::run();
+
+        $this->assertSame(['x' => 1, 'y' => 2], $resolved);
+    }
+
+    public function testAllWithMixedFuturesAndPromises(): void
+    {
+        $future = Future::complete('future-val');
+        $promise = $this->adapter->createFulfilled('promise-val');
+
+        $allPromise = $this->adapter->all([$future, $promise]);
+
+        $resolved = null;
+        EventLoop::queue(static function () use ($allPromise, &$resolved): void {
+            /** @var Future<mixed> $future */
+            $future = $allPromise->adoptedPromise;
+            $resolved = $future->await();
+        });
+        EventLoop::run();
+
+        $this->assertSame(['future-val', 'promise-val'], $resolved);
+    }
+
+    public function testAllAcceptsIterator(): void
+    {
+        $items = (static function () {
+            yield 'a' => Future::complete(10);
+            yield 'b' => Future::complete(20);
+        })();
+
+        $allPromise = $this->adapter->all($items);
+
+        $resolved = null;
+        EventLoop::queue(static function () use ($allPromise, &$resolved): void {
+            /** @var Future<mixed> $future */
+            $future = $allPromise->adoptedPromise;
+            $resolved = $future->await();
+        });
+        EventLoop::run();
+
+        $this->assertSame(['a' => 10, 'b' => 20], $resolved);
+    }
+
+    // ------------------------------------------------------------------ deferred resolution via create+then chain
+
+    public function testDeferredFutureResolvesCorrectly(): void
+    {
+        $deferred = new DeferredFuture();
+
+        $promise = $this->adapter->convertThenable($deferred->getFuture());
+
+        $result = null;
+        $chainedPromise = $this->adapter->then(
+            $promise,
+            static function ($value) use (&$result): mixed {
+                $result = $value;
+                return $value;
+            }
+        );
+
+        EventLoop::queue(static function () use ($deferred, $chainedPromise): void {
+            $deferred->complete('deferred-result');
+            /** @var Future<mixed> $future */
+            $future = $chainedPromise->adoptedPromise;
+            $future->await();
+        });
+        EventLoop::run();
+
+        $this->assertSame('deferred-result', $result);
+    }
+}


### PR DESCRIPTION
This pull request adds first-class support for Amphp v3 asynchronous execution to the project, enabling fully non-blocking GraphQL operations. The main changes include the introduction of a new `AmpFutureAdapter` for integrating Amphp `Future` objects with the `webonyx/graphql-php` promise system, as well as comprehensive documentation and usage instructions in the `README.md`.

**Amphp v3 async execution support:**

* Added a new `AmpFutureAdapter` class in `src/Executor/AmpFutureAdapter.php` to bridge Amphp v3 `Future` objects with the `webonyx/graphql-php` promise system, providing all required methods for promise adaptation, including handling of fulfilled, rejected, and combined promises.

**Documentation improvements:**

* Updated the `README.md` to add a dedicated section on Amphp v3 async execution, including setup instructions, usage notes, and installation guidance for the `amphp/amp` package.
* Improved the feature list in `README.md` by linking to the new Amphp v3 async execution documentation.